### PR TITLE
feat: support tags in search results

### DIFF
--- a/src/components/grid/WebsiteGrid.vue
+++ b/src/components/grid/WebsiteGrid.vue
@@ -37,6 +37,14 @@ const localWebsites = computed({
 const filteredWebsites = computed(() => {
   const query = uiStore.searchQuery.toLowerCase().trim()
   const currentPageSites = websitesStore.currentPageWebsites
+  const previewTagId = uiStore.previewTagId
+
+  // If there's a preview tag (arrow key navigation), filter by that tag
+  if (previewTagId) {
+    return currentPageSites.filter((website: Website) =>
+      website.tagIds && website.tagIds.includes(previewTagId)
+    )
+  }
 
   if (!query) {
     return currentPageSites

--- a/src/components/grid/WebsiteGrid.vue
+++ b/src/components/grid/WebsiteGrid.vue
@@ -190,10 +190,15 @@ onUnmounted(() => {
   align-items: flex-start;
   justify-content: center;
   padding: var(--grid-padding);
-  padding-top: 140px;
+  padding-top: calc(140px + var(--dropdown-offset, 0px));
   padding-bottom: 100px;
   overflow-x: hidden;
   overflow-y: auto;
+  position: relative;
+
+  /* Spring animation for grid displacement with 50ms delay for choreographed motion */
+  transition: padding-top 350ms cubic-bezier(0.34, 1.56, 0.64, 1) 50ms;
+  will-change: padding-top;
 }
 
 .website-grid {
@@ -374,14 +379,14 @@ onUnmounted(() => {
 
 @media (max-width: 1024px) {
   .grid-container {
-    padding-top: 140px;
+    padding-top: calc(140px + var(--dropdown-offset, 0px));
     padding-bottom: 80px;
   }
 }
 
 @media (max-width: 640px) {
   .grid-container {
-    padding-top: 110px;
+    padding-top: calc(110px + var(--dropdown-offset, 0px));
     padding-bottom: 70px;
   }
 

--- a/src/components/layout/SearchBar.vue
+++ b/src/components/layout/SearchBar.vue
@@ -21,7 +21,6 @@ const localSearchQuery = ref(uiStore.searchQuery)
 const showTagSuggestions = ref(false)
 const highlightedIndex = ref(-1)
 const positionUpdateTrigger = ref(0) // Used to trigger position recalculation
-const tagSuggestionsElement = ref<HTMLElement | null>(null)
 const dropdownHeight = ref(0)
 
 // Debounced search update to store (reduces re-renders)

--- a/src/components/layout/SearchBar.vue
+++ b/src/components/layout/SearchBar.vue
@@ -366,7 +366,7 @@ function openSettings() {
         :style="suggestionsPosition"
       >
         <div class="suggestions-header">
-          <span class="suggestions-title">Categories</span>
+          <span class="suggestions-title">Tags</span>
           <span class="suggestions-count">
             {{ filteredTagSuggestions.length }}
           </span>

--- a/src/components/layout/SearchBar.vue
+++ b/src/components/layout/SearchBar.vue
@@ -208,6 +208,9 @@ function updateGridOffset() {
 function attachObserverToDropdown() {
   const dropdown = document.querySelector('.tag-suggestions')
   if (dropdown && resizeObserver) {
+    // Disconnect any previous observations to avoid duplicates
+    resizeObserver.disconnect()
+    // Observe the new dropdown element
     resizeObserver.observe(dropdown as HTMLElement)
     // Force initial measurement
     const rect = dropdown.getBoundingClientRect()
@@ -229,6 +232,17 @@ watch(showTagSuggestions, async (isVisible) => {
     // Immediately clear offset when dropdown closes
     dropdownHeight.value = 0
     updateGridOffset()
+  }
+})
+
+// Also watch for dropdown content changes (when filtering changes)
+watch(filteredTagSuggestions, async () => {
+  if (showTagSuggestions.value) {
+    // Dropdown is visible but content changed, reattach observer
+    await nextTick()
+    setTimeout(() => {
+      attachObserverToDropdown()
+    }, 50)
   }
 })
 

--- a/src/components/layout/SearchBar.vue
+++ b/src/components/layout/SearchBar.vue
@@ -88,6 +88,9 @@ function handleInput(e: Event) {
   const value = (e.target as HTMLInputElement).value
   localSearchQuery.value = value
 
+  // Clear preview when user types (they're searching manually now)
+  uiStore.clearPreviewTag()
+
   // Update store with debounce (reduces re-renders in WebsiteGrid)
   updateSearchQuery(value)
 
@@ -117,6 +120,8 @@ function selectTagSuggestion(tag: any) {
   uiStore.setSearchQuery(newQuery)
   showTagSuggestions.value = false
   highlightedIndex.value = -1
+  // Clear preview since we've committed the selection
+  uiStore.clearPreviewTag()
 
   // Keep focus on search input
   searchInput.value?.focus()
@@ -125,6 +130,7 @@ function selectTagSuggestion(tag: any) {
 function closeSuggestions() {
   showTagSuggestions.value = false
   highlightedIndex.value = -1
+  uiStore.clearPreviewTag()
 }
 
 function handleKeydownInSuggestions(e: KeyboardEvent) {
@@ -166,10 +172,20 @@ function handleKeydownInSuggestions(e: KeyboardEvent) {
         highlightedIndex.value + 1,
         suggestions.length - 1
       )
+      // Update preview to show websites for highlighted tag
+      if (highlightedIndex.value >= 0) {
+        uiStore.setPreviewTag(suggestions[highlightedIndex.value].id)
+      }
       break
     case 'ArrowUp':
       e.preventDefault()
       highlightedIndex.value = Math.max(highlightedIndex.value - 1, -1)
+      // Update preview to show websites for highlighted tag
+      if (highlightedIndex.value >= 0) {
+        uiStore.setPreviewTag(suggestions[highlightedIndex.value].id)
+      } else {
+        uiStore.clearPreviewTag()
+      }
       break
     case 'Enter':
       e.preventDefault()
@@ -363,7 +379,7 @@ function openSettings() {
             :class="{ highlighted: index === highlightedIndex }"
             :style="{ '--tag-hover-bg': tag.color + '12', color: tag.color }"
             @click="selectTagSuggestion(tag)"
-            @mouseenter="highlightedIndex = index"
+            @mouseenter="() => { highlightedIndex = index; uiStore.setPreviewTag(tag.id); }"
           >
             <span
               class="tag-color-dot"

--- a/src/stores/__tests__/uiStore.spec.ts
+++ b/src/stores/__tests__/uiStore.spec.ts
@@ -13,6 +13,7 @@ describe('uiStore', () => {
       const store = useUIStore()
 
       expect(store.searchQuery).toBe('')
+      expect(store.previewTagId).toBeNull()
       expect(store.isEditMode).toBe(false)
       expect(store.showWebsiteForm).toBe(false)
       expect(store.showSettingsModal).toBe(false)
@@ -39,6 +40,61 @@ describe('uiStore', () => {
 
       store.clearSearch()
       expect(store.searchQuery).toBe('')
+    })
+
+    it('should clear both search query and preview tag', () => {
+      const store = useUIStore()
+
+      store.setSearchQuery('test query')
+      store.setPreviewTag('tag-123')
+      expect(store.searchQuery).toBe('test query')
+      expect(store.previewTagId).toBe('tag-123')
+
+      store.clearSearch()
+      expect(store.searchQuery).toBe('')
+      expect(store.previewTagId).toBeNull()
+    })
+  })
+
+  describe('preview tag functionality', () => {
+    it('should set preview tag ID', () => {
+      const store = useUIStore()
+
+      store.setPreviewTag('tag-123')
+      expect(store.previewTagId).toBe('tag-123')
+    })
+
+    it('should clear preview tag ID', () => {
+      const store = useUIStore()
+
+      store.setPreviewTag('tag-123')
+      expect(store.previewTagId).toBe('tag-123')
+
+      store.clearPreviewTag()
+      expect(store.previewTagId).toBeNull()
+    })
+
+    it('should update preview tag when navigating', () => {
+      const store = useUIStore()
+
+      store.setPreviewTag('tag-1')
+      expect(store.previewTagId).toBe('tag-1')
+
+      store.setPreviewTag('tag-2')
+      expect(store.previewTagId).toBe('tag-2')
+
+      store.setPreviewTag('tag-3')
+      expect(store.previewTagId).toBe('tag-3')
+    })
+
+    it('should set preview tag to null explicitly', () => {
+      const store = useUIStore()
+
+      store.setPreviewTag('tag-123')
+      expect(store.previewTagId).toBe('tag-123')
+
+      store.setPreviewTag(null)
+      expect(store.previewTagId).toBeNull()
     })
   })
 

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -6,6 +6,7 @@ import type { Website, Tag, ConfirmDialogConfig } from '../types'
 export const useUIStore = defineStore('ui', () => {
   // State
   const searchQuery: Ref<string> = ref('')
+  const previewTagId: Ref<string | null> = ref(null) // For arrow key navigation preview
   const isEditMode: Ref<boolean> = ref(false)
   const showWebsiteForm: Ref<boolean> = ref(false)
   const showSettingsModal: Ref<boolean> = ref(false)
@@ -33,6 +34,15 @@ export const useUIStore = defineStore('ui', () => {
 
   function clearSearch(): void {
     searchQuery.value = ''
+    previewTagId.value = null
+  }
+
+  function setPreviewTag(tagId: string | null): void {
+    previewTagId.value = tagId
+  }
+
+  function clearPreviewTag(): void {
+    previewTagId.value = null
   }
 
   function openWebsiteForm(website: Website | null = null): void {
@@ -132,6 +142,7 @@ export const useUIStore = defineStore('ui', () => {
   return {
     // State
     searchQuery,
+    previewTagId,
     isEditMode,
     showWebsiteForm,
     showSettingsModal,
@@ -149,6 +160,8 @@ export const useUIStore = defineStore('ui', () => {
     // Actions
     setSearchQuery,
     clearSearch,
+    setPreviewTag,
+    clearPreviewTag,
     enterEditMode,
     exitEditMode,
     toggleEditMode,


### PR DESCRIPTION
- Display tags if they match the search query. 
- Add an animation so the icons are pushed down to avoid been covered by the tags menu
- Enhance website discovery on tag selection with arrows

Closes #12 .